### PR TITLE
Fix issue with rename script hitting geo resources

### DIFF
--- a/scripts/rename
+++ b/scripts/rename
@@ -52,5 +52,4 @@ grep -rl "\"bifrost\"" .    | grep -v -e $IGNORES | xargs sed -i '' "s/\"bifrost
 
 grep -rl "bifrost json" .   | grep -v -e $IGNORES | xargs sed -i '' "s/bifrost json/$DEPLOYER json/g"
 
-
-
+grep -rl "coinbase" ./resources   | grep -v -e $IGNORES | xargs sed -i '' "s/coinbase/$ORG/g"


### PR DESCRIPTION
Previously the orgname in the project definition and tags were not getting updated in the geoengineer resources file, and would remain as "coinbase"